### PR TITLE
Removing zero-width spaces before parsing urls (and #!/usr/bin/env ruby)

### DIFF
--- a/lib/url-grabber.rb
+++ b/lib/url-grabber.rb
@@ -16,6 +16,7 @@ class UrlGrabber
     # don't reply to urls posted by self
     return if m.user.nick == $config[:cinch][:nick]
 
+    m.message.gsub! /\u200B/, '' # remove zero-width spaces from message
     bot.logger.debug("received url(s): #{m.message}")
     file_output = {}
     extract_urls(m.message).each do |url|

--- a/lib/url-grabber.rb
+++ b/lib/url-grabber.rb
@@ -35,7 +35,7 @@ class UrlGrabber
   end
 
   def self.sanitize_title(title)
-    HTMLEntities.new.decode(title.gsub(/\r?\n/, " ").strip)
+    HTMLEntities.new.decode(title.gsub(/\r?\n/, " ").strip).gsub! /\s+/, ' '
   end
 
   def self.extract_title(logger, url)

--- a/url-bot.rb
+++ b/url-bot.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby1.9.1
+#!/usr/bin/env ruby
 
 require 'rubygems'
 require 'bundler/setup'


### PR DESCRIPTION
- url-grabber removes zero-width spaces (U+200B) before parsing the message to find an url.
- Changed url-bot.rb shebang to run /usr/bin/env ruby instead of /usr/bin/ruby-1.9.1.
