### PR TITLE
Fixed double-posting.

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -16,10 +16,9 @@ class GitHub
       url = GitHub.reference_url(reference)
       if not url.nil?
         title, status = UrlGrabber.extract_title bot.logger, url
-        m.reply("#{m.user.nick}: #{url} - #{title.gsub(/ - Issues - .*$/, '')}")
+	title.gsub!(/ - GitHub$/, '')
+        m.reply("#{m.user.nick}: #{url} - #{reference[:issue].nil? ? title : title.gsub(/ - Issues.*/, '')}")
       end
-      title, status = UrlGrabber.extract_title bot.logger, url
-      m.reply("#{m.user.nick}: #{url} - #{title}")
     end
   end
 


### PR DESCRIPTION
- Removed double-posting from github plugin.
- Formatted output not to remove "Issues" from title when doing
  gh:frost/hink/issues, and only when having an issue number, #nn.
  
  [12:27:39] <@Lemming^> gh:frost/hink/issues
  [12:27:48] < Hunk> Lemming^: https://github.com/frost/hink/issues - Issues - Frost/hink
  [12:28:05] <@Lemming^> gh:frost/hink#11
  [12:28:08] < Hunk> Lemming^: https://github.com/frost/hink/issues/11 - #11: Title whitespace trimming and fixing
  [12:28:18] <@Lemming^> gh:frost
  [12:28:22] < Hunk> Lemming^: https://github.com/frost - Frost's Profile
  [12:28:26] <@Lemming^> gh:frost/hink
  [12:28:27] < Hunk> Lemming^: https://github.com/frost/hink - Frost/hink
