### PR TITLE
url-grabber html output fix

### DIFF
--- a/lib/url-grabber.rb
+++ b/lib/url-grabber.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'cinch'
 require 'json'
 require 'open-uri'
@@ -29,7 +30,7 @@ class UrlGrabber
       m.reply("#{title} | #{url_to_use} // #{m.user.nick}") if status == :ok
     end
     output_file = $config[:url_grabber][:url_dir] + "/" + m.channel.name.gsub(/^#/,'') + ".html"
-    write_output_to_file(output_file, file_output, m.user.nick)
+    write_output_to_file(output_file, file_output, m.user.nick, m.channel.name)
   end
 
   def extract_urls(message)
@@ -92,12 +93,27 @@ class UrlGrabber
     return :error
   end
 
-  def write_output_to_file(file, urls = {}, user= '?')
+  def write_output_to_file(file, urls = {}, user = '?', channel = '?')
     bot.logger.debug("writing to #{file}")
 	html = HTMLEntities.new
     File.open(file, 'a') do |f|
+	  if f.size == 0
+	    f << %{
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>#{channel} - Länksamling</title>
+    <style>
+      a:hover {color: red;}
+    </style>
+  </head>
+<body>
+  <pre>
+}
+	  end
       urls.each do |url, title|
-        f.write(%(#{Time.now} &lt;#{html.encode user}&gt;: <a href="#{url[:url]}">#{html.encode title}</a>#{url[:bitly].nil? ? '' : %{<a href="#{url[:bitly]}">#{url[:bitly]}</a>}}\n<br/>\n))
+        f.write(%(#{Time.now} &lt;#{html.encode user}&gt;: <a href="#{url[:url]}">#{html.encode title}</a>#{url[:bitly].nil? ? '' : %{<a href="#{url[:bitly]}">#{url[:bitly]}</a>}}\n))
       end
     end
   end

--- a/lib/url-grabber.rb
+++ b/lib/url-grabber.rb
@@ -30,7 +30,7 @@ class UrlGrabber
       m.reply("#{title} | #{url_to_use} // #{m.user.nick}") if status == :ok
     end
     output_file = $config[:url_grabber][:url_dir] + "/" + m.channel.name.gsub(/^#/,'') + ".html"
-    write_output_to_file(output_file, file_output, m.user.nick, m.channel.name)
+    write_output_to_file(output_file, file_output, m.channel.name)
   end
 
   def extract_urls(message)
@@ -93,7 +93,7 @@ class UrlGrabber
     return :error
   end
 
-  def write_output_to_file(file, urls = {}, user = '?', channel = '?')
+  def write_output_to_file(file, urls = {}, channel = '?')
     bot.logger.debug("writing to #{file}")
 	html = HTMLEntities.new
     File.open(file, 'a') do |f|
@@ -113,7 +113,7 @@ class UrlGrabber
 }
 	  end
       urls.each do |url, title|
-        f.write(%(#{Time.now} &lt;#{html.encode user}&gt;: <a href="#{url[:url]}">#{html.encode title}</a>#{url[:bitly].nil? ? '' : %{<a href="#{url[:bitly]}">#{url[:bitly]}</a>}}\n))
+        f.write(%(#{Time.now}: <a href="#{url[:url]}">#{html.encode title}</a>#{url[:bitly].nil? ? '' : %{<a href="#{url[:bitly]}">#{url[:bitly]}</a>}}\n))
       end
     end
   end


### PR DESCRIPTION
- Added &lt;br/&gt; after each url.
- Added nicknames to output.
- Check for short_url (from bitlyfy) being nil.
- Outputs both url and bitly short version (elegantly).
  Only adds bitly short version when it's not nil.
